### PR TITLE
Full V2 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+## v1.0.0 (2020-09-25)
+
+Remove use of the https://graph.microsoft.com/v1.0/me API …
+
+* One of the key differences for the V2 API vs V1 is the differences
+  between who can sign with the addition of Personal Accounts see:
+  https://nicolgit.github.io/AzureAD-Endopoint-V1-vs-V2-comparison/
+
+  - In testing found that these accounts may not have access to this
+    endpoint
+  - All the data provided in `info` exists in the JWT anyway this
+    cuts down on API calls
+
+* Conform to the Omniauth Auth Hash Schema (1.0 and later) see:
+  https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema
+
+  - Expose raw_info
+  - Remove `id` from `info`
+    - *NB: This could be a breaking change for some however most will
+          be using the correct location `uid`*
+
+## v0.1.1 (2020-09-23)
+
+- First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Remove use of the https://graph.microsoft.com/v1.0/me API …
 
   - In testing found that these accounts may not have access to this
     endpoint
-  - All the data provided in `info` exists in the JWT anyway this
+  - All the data provided in `info` exists in the JWT anyway, so this
     cuts down on API calls
 
 * Conform to the Omniauth Auth Hash Schema (1.0 and later) see:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Omniauth::Azure::Activedirectory::V2
 
+[![Gem Version](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2.svg)](https://badge.fury.io/rb/omniauth-azure-activedirectory-v2)
+[![Build Status](https://travis-ci.org/RIPGlobal/omniauth-azure-activedirectory-v2.svg)](https://travis-ci.org/RIPGlobal/omniauth-azure-activedirectory-v2)
+[![License](https://img.shields.io/github/license/RIPGlobal/omniauth-azure-activedirectory-v2.svg)](LICENSE.md)
+
 OAuth 2 authentication with [Azure ActiveDirectory's V2 API](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-overview). Rationale:
 
 * https://github.com/marknadig/omniauth-azure-oauth2 is no longer maintained.
 * https://github.com/marknadig/omniauth-azure-oauth2/pull/29 contains important additions.
 
-This gem combines the two.
+This gem combines the two and makes some changes to support the full V2 API.
 
 The ActiveDirectory V1 auth API used OpenID Connect. If you need this, a gem from Microsoft [is available here](https://github.com/AzureAD/omniauth-azure-activedirectory), but seems to be abandoned.
 

--- a/lib/omniauth/azure_activedirectory_v2/version.rb
+++ b/lib/omniauth/azure_activedirectory_v2/version.rb
@@ -2,7 +2,7 @@ module Omniauth
   module Azure
     module Activedirectory
       module V2
-        VERSION = "0.1.1"
+        VERSION = "1.0.0"
       end
     end
   end

--- a/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_v2_spec.rb
@@ -284,36 +284,37 @@ RSpec.describe OmniAuth::Strategies::AzureActivedirectoryV2 do
       OmniAuth::Strategies::AzureActivedirectoryV2.new(app, {client_id: 'id', client_secret: 'secret'})
     end
 
+    let(:token_info) do
+      {
+          oid:         'my_id',
+          name:        'Bob Doe',
+          email:       'bob@doe.com',
+          unique_name: 'bobby',
+          given_name:  'Bob',
+          family_name: 'Doe'
+      }
+    end
+
+    let(:token) do
+      JWT.encode(token_info, "secret")
+    end
+
     let(:access_token) do
-      double
+      double(:token => token)
     end
 
     before do
       allow(subject).to receive(:access_token) { access_token }
       allow(subject).to receive(:request) { request }
-      expect(access_token)
-          .to receive(:get)
-                  .with('https://graph.microsoft.com/v1.0/me')
-                  .and_return(
-                      double({
-                                 parsed: {
-                                     'id' => 'my_id',
-                                     'displayName' => 'Bob Doe',
-                                     'givenName' => 'Bob',
-                                     'surname' => 'Doe',
-                                     'userPrincipalName' => 'bob@doe.com'
-                                 }
-                             })
-                  )
     end
 
     it "info returns correct info" do
       expect(subject.info).to eq({
-                                     email: 'bob@doe.com',
+                                     name:       'Bob Doe',
+                                     email:      'bob@doe.com',
+                                     nickname:   'bobby',
                                      first_name: 'Bob',
-                                     id: 'my_id',
-                                     last_name: 'Doe',
-                                     name: 'Bob Doe',
+                                     last_name:  'Doe'
                                  })
     end
 


### PR DESCRIPTION
#### Remove use of the https://graph.microsoft.com/v1.0/me API
* One of the key differences for the V2 API vs V1 is the differences
  between who can sign with the addition of Personal Accounts see:
  https://nicolgit.github.io/AzureAD-Endopoint-V1-vs-V2-comparison/

  - In testing found that these accounts may not have access to this
    endpoint
  - All the data provided in `info` exists in the JWT anyway, so this
    cuts down on API calls

* Conform to the Omniauth Auth Hash Schema (1.0 and later) see:
  https://github.com/omniauth/omniauth/wiki/Auth-Hash-Schema

  - Expose raw_info
  - Remove `id` from `info`
    - NB: This could be a breaking change for some however most will
          be using the correct location `uid`